### PR TITLE
s/dependencies/devDependencies/.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "url": "https://github.com/3rd-Eden/commenting/issues"
   },
   "homepage": "https://github.com/3rd-Eden/commenting#readme",
-  "dependencies": {
+  "devDependencies": {
     "assume": "1.2.x",
     "istanbul": "0.3.x",
     "mocha": "2.2.x",


### PR DESCRIPTION
Noticed this when I was installing it. Assuming that having these as `dependencies` was a typo.
