### PR TITLE
fix: keep empty lines instead of single space

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ var extension = Object.create(null)
  * @api private
  */
 function Style(body, start, end) {
-  this.body = body +' ';
+  this.body = body;
   this.end = end || body;
   this.start = start || body;
 }
@@ -77,7 +77,7 @@ function commenting(text, options) {
   // fewer Array.push calls for larger comments.
   //
   Array.prototype.push.apply(comment, text.map(function each(line) {
-    return style.body + line.trim();
+    return style.body + (line ? ' ' + line.trim() : '');
   }));
 
   comment.push(style.end);

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/3rd-Eden/commenting#readme",
   "devDependencies": {
-    "assume": "1.2.x",
+    "assume": "1.4.x",
     "istanbul": "0.3.x",
     "mocha": "2.2.x",
     "pre-commit": "1.0.x"

--- a/test.js
+++ b/test.js
@@ -29,6 +29,18 @@ describe('commenting', function () {
     assume(comment).includes(' */\n');
   });
 
+  it('keep empty lines', function () {
+    var comment = commenting(['hello', '', 'world'], {
+      extension: '.js'
+    });
+
+    assume(comment).includes('/**\n');
+    assume(comment).includes(' * hello\n');
+    assume(comment).includes(' *\n');
+    assume(comment).includes(' * world\n');
+    assume(comment).includes(' */\n');
+  });
+
   it('uses the supplied style', function () {
     var comment = commenting('hello  ', {
       style: commenting.styles.slash


### PR DESCRIPTION
When an empty space is added, a space is added to the comment line.
This commit change this, and keep empty line as it is.
Package assume is also updated because of bad ansi-codes dependency.