### PR TITLE
fix: appcache file use hash style

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,6 +43,7 @@ extension['.coffee'] = styles.triple;
 
 extension['.jade'] = styles.slash;
 
+extension['.appcache'] =
 extension[''] = styles.hash;
 
 /**

--- a/test.js
+++ b/test.js
@@ -79,4 +79,13 @@ describe('commenting', function () {
     assume(comment).includes('# hello\n');
     assume(comment).includes('# world\n');
   });
+
+  it('maps appcache extension to hash', function () {
+    var comment = commenting(['hello', 'world'], {
+      extension: '.appcache'
+    });
+
+    assume(comment).includes('# hello\n');
+    assume(comment).includes('# world\n');
+  });
 });


### PR DESCRIPTION
File with extension `.appcache` should use comments with hash style.
See: https://www.html5rocks.com/en/tutorials/appcache/beginner/