### PR TITLE
Adding correct comment style for .SVG files

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ styles.html = new Style(' //', '<!--', '-->');
 // Assign the different extensions to their correct commenting styles.
 //
 extension['.htm'] =
+extension['.svg'] =
 extension['.html'] = styles.html;
 
 extension['.js'] =


### PR DESCRIPTION
Previously .svg files comments were being rendered the same as .css. They should have been the same as .html