### PR TITLE
feat: add option for keeping indent

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,6 +69,7 @@ function commenting(text, options) {
   if (options.extension && options.extension.charAt(0) !== '.') {
     options.extension = '.'+ options.extension;
   }
+  var keepIndent = !!options.keepIndent
 
   var style = options.style || extension[options.extension] || styles.star
     , comment = [];
@@ -80,7 +81,7 @@ function commenting(text, options) {
   // fewer Array.push calls for larger comments.
   //
   Array.prototype.push.apply(comment, text.map(function each(line) {
-    return style.body + (line ? ' ' + line.trim() : '');
+    return style.body + (line ? ' ' + (keepIndent ? line.trimEnd() : line.trim()) : '');
   }));
 
   comment.push(style.end);

--- a/test.js
+++ b/test.js
@@ -20,12 +20,24 @@ describe('commenting', function () {
   });
 
   it('trims comments', function () {
-    var comment = commenting('hello  ', {
+    var comment = commenting('  hello  ', {
       extension: '.js'
     });
 
     assume(comment).includes('/**\n');
     assume(comment).includes(' * hello\n');
+    assume(comment).includes(' */\n');
+  });
+
+  it('keeps each comments indented', function () {
+    var comment = commenting(['hello  ',  '    world'], {
+      extension: '.js',
+      keepIndent: true
+    });
+
+    assume(comment).includes('/**\n');
+    assume(comment).includes(' * hello\n');
+    assume(comment).includes(' *     world\n');
     assume(comment).includes(' */\n');
   });
 


### PR DESCRIPTION
I want to keep the indent for each line.
For example, if it is needed to embed markdown (or, any other document format) in a comment, or if it is needed the indents to align when you break in the middle of a bulleted item.

```
- some
  - nested
  - list
- keep
  indented
```
to be
```
/**
 * - some
 *   - nested
 *   - list
 * - keep
 *   indented
 */